### PR TITLE
prevent unnecessary editor updates

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Jonas Ulrich (ruhmesmeile GmbH)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It was slightly modified to generate bundles that can be imported for partial us
 
 `JSON Code Editor` is based on [@monaco-editor/react](https://github.com/suren-atoyan/monaco-react). The editor is connected to your story state / args, so changing props through `Controls` is reflected in the code shown. Vice-versa if you edit the JSON, and the result is valid according to the schema, your changed args are applied to the story, too.
 
-**[Show me a working demo](https://www.kickstartds.com)**
+**[Show me a working demo](https://www.kickstartds.com/storybook/?path=/story/content-visual--box-light)** (click on the `JSON Schema` addon tab)
 
 ![Teaser image](docs/teaser.png)
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@storybook/addon-essentials": "^6.3.6",
     "@storybook/react": "^6.3.6",
     "@types/styled-components": "^5.1.15",
-    "@types/throttle-debounce": "^2.1.0",
     "auto": "^10.3.0",
     "babel-loader": "^8.1.0",
     "boxen": "^5.0.1",
@@ -107,7 +106,6 @@
     "decomment": "^0.9.4",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
-    "styled-components": "^5.3.1",
-    "throttle-debounce": "^3.0.1"
+    "styled-components": "^5.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/kickstartDS/storybook-addon-jsonschema"
   },
   "author": "Jonas Ulrich | ruhmesmeile GmbH",
+  "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/ts/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "icon": "https://opencollective-production.s3.us-west-1.amazonaws.com/1e445ca0-fca9-11e9-a830-c36c137aded5.png"
   },
   "dependencies": {
-    "@kickstartds/json-schema-viewer": "^1.0.12",
+    "@kickstartds/json-schema-viewer": "^1.1.0",
     "@monaco-editor/react": "^4.3.1",
     "@types/decomment": "^0.9.2",
     "@types/js-yaml": "^4.0.3",

--- a/src/components/SchemaDoc.tsx
+++ b/src/components/SchemaDoc.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { useLocation } from "react-router-dom";
+
+import {
+  SchemaExplorer,
+  SchemaExplorerProps,
+  Lookup,
+  InternalLookup,
+  PathElement,
+  getSchemaFromReference,
+  JsonSchema,
+} from "@kickstartds/json-schema-viewer";
+
+const getTitle = (schema: JsonSchema | undefined): string => {
+  if (schema === undefined) {
+    return "<not found>";
+  }
+
+  if (typeof schema === "boolean") {
+    return "<anything>";
+  }
+
+  return schema.title || "object";
+};
+
+const removeLeadingSlash = (v: string): string => {
+  if (v.startsWith("/")) {
+    return v.slice(1);
+  }
+  return v;
+};
+
+type SchemaDocProps = {
+  schema: JsonSchema;
+};
+
+export const SchemaDoc: React.FC<SchemaDocProps> = ({ schema }) => {
+  const lookup = new InternalLookup(schema);
+
+  const getPathFromRoute = (lookup: Lookup): Array<PathElement> => {
+    const basePathSegments = ["base"];
+    const { pathname } = useLocation();
+    const pathSegments = removeLeadingSlash(pathname).split("/");
+    let iterator = 0;
+    while (
+      pathSegments[iterator] !== undefined &&
+      basePathSegments[iterator] !== undefined &&
+      basePathSegments[iterator] === pathSegments[iterator]
+    ) {
+      iterator++;
+    }
+
+    if (iterator === pathSegments.length) {
+      const reference = "#";
+      const title = getTitle(getSchemaFromReference(reference, lookup));
+      return [
+        {
+          title,
+          reference,
+        },
+      ];
+    }
+
+    return pathSegments
+      .slice(iterator)
+      .map(decodeURIComponent)
+      .map((userProvidedReference) => {
+        const reference = userProvidedReference.startsWith("#")
+          ? userProvidedReference
+          : "#/invalid-reference";
+        const title = getTitle(getSchemaFromReference(reference, lookup));
+        return {
+          title,
+          reference,
+        };
+      });
+  };
+
+  const path = getPathFromRoute(lookup);
+  if (path.length === 0) {
+    return <div>Error: Could not work out what to load from the schema.</div>;
+  }
+
+  const currentPathElement = path[path.length - 1];
+  const currentSchema = getSchemaFromReference(
+    currentPathElement.reference,
+    lookup
+  );
+
+  if (currentSchema === undefined) {
+    return (
+      <div>
+        ERROR: Could not look up the schema that was requested in the URL.
+      </div>
+    );
+  }
+
+  if (typeof currentSchema === "boolean") {
+    return (
+      <div>TODO: Implement anything or nothing schema once clicked on.</div>
+    );
+  }
+
+  const explorerArgs: SchemaExplorerProps = {
+    basePathSegments: ["base"],
+    path,
+    lookup,
+    schema: currentSchema,
+    stage: "both",
+  };
+
+  return <SchemaExplorer {...explorerArgs} />;
+};

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -1,14 +1,20 @@
-import React, { useEffect, useRef } from "react";
-import Editor, { useMonaco, OnMount, OnValidate, OnChange } from "@monaco-editor/react";
+import React, { useEffect, useRef, useMemo } from "react";
+import Editor, {
+  useMonaco,
+  OnMount,
+  OnValidate,
+  OnChange,
+} from "@monaco-editor/react";
 import { JsonSchema } from "@kickstartds/json-schema-viewer";
+import { pack, unpack } from "@kickstartds/core/lib/storybook/helpers";
+import { useArgs } from "@storybook/api";
+import decomment from "decomment";
 
 type OnChangeParams = Parameters<OnChange>;
 
 type SchemaEditorProps = {
-  initialContent: unknown;
   schema: JsonSchema;
-  handleValidChange: (value: OnChangeParams[0]) => void;
-}
+};
 
 const editorPreamble = `
 // Copy-and-paste your JSON in here to live-edit
@@ -16,17 +22,26 @@ const editorPreamble = `
 // benefit of validation and autocompletion!
 `.trim();
 
-export const SchemaEditor: React.FC<SchemaEditorProps> = (props) => {
+export const SchemaEditor: React.FC<SchemaEditorProps> = ({ schema }) => {
   const editorRef = useRef(null);
   const monaco = useMonaco();
+  const [storybookArgs, updateArgs] = useArgs();
+
+  const initialContent = useMemo(() => unpack(storybookArgs), [schema]);
 
   const handleEditorDidMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
   };
 
+  const handleChange = (value: OnChangeParams[0]) => {
+    try {
+      updateArgs(pack(JSON.parse(decomment(value))));
+    } catch (e) {}
+  };
+
   const handleEditorValidChange: OnValidate = (markers) => {
     if (markers.length === 0 && editorRef && editorRef.current) {
-      props.handleValidChange(editorRef.current.getValue());
+      handleChange(editorRef.current.getValue());
     }
   };
 
@@ -34,27 +49,27 @@ export const SchemaEditor: React.FC<SchemaEditorProps> = (props) => {
     monaco?.languages.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,
       allowComments: true,
-      schemas: [{
-        uri: "https://json-schema.app/example.json", // id of the first schema
-        fileMatch: ['a://b/example.json'],
-        schema: props.schema
-      }]
+      schemas: [
+        {
+          uri: "https://json-schema.app/example.json", // id of the first schema
+          fileMatch: ["a://b/example.json"],
+          schema: schema,
+        },
+      ],
     });
-  }, [monaco, props.schema]);
+  }, [monaco, schema]);
 
   return (
     <Editor
       height="97vh"
       defaultLanguage="json"
-      value={
-        editorPreamble + "\n" + JSON.stringify(props.initialContent, null, 2)
-      }
+      value={editorPreamble + "\n" + JSON.stringify(initialContent, null, 2)}
       path="a://b/example.json"
       theme="vs-dark"
       onValidate={handleEditorValidChange}
       saveViewState={false}
       onMount={handleEditorDidMount}
-      onChange={props.handleValidChange}
+      onChange={handleChange}
     />
   );
 };

--- a/src/components/SchemaView.tsx
+++ b/src/components/SchemaView.tsx
@@ -1,24 +1,12 @@
-import React, { useCallback } from "react";
-import { useLocation } from 'react-router-dom';
-import { useArgs, useParameter } from "@storybook/api";
+import React from "react";
+import { useParameter } from "@storybook/api";
 import styled from "styled-components";
-import decomment from "decomment";
-import { debounce } from "throttle-debounce";
 
-import {
-  SchemaExplorer,
-  SchemaExplorerProps,
-  Lookup,
-  InternalLookup,
-  PathElement,
-  getSchemaFromReference,
-  forSize,
-  JsonSchema,
-} from "@kickstartds/json-schema-viewer";
-import { pack, unpack } from "@kickstartds/core/lib/storybook/helpers";
+import { forSize, JsonSchema } from "@kickstartds/json-schema-viewer";
 
-import { PARAM_KEY } from '../constants';
-import { SchemaEditor } from './SchemaEditor';
+import { PARAM_KEY } from "../constants";
+import { SchemaDoc } from "./SchemaDoc";
+import { SchemaEditor } from "./SchemaEditor";
 
 const SchemaContainer = styled.div`
   display: flex;
@@ -30,9 +18,7 @@ const SchemaEditorContainer = styled.div`
 
   display: none;
   position: relative;
-  ${forSize('tablet-landscape-up', `
-    display: block;
-  `)}
+  ${forSize("tablet-landscape-up", "display: block;")}
 
   section {
     position: fixed !important;
@@ -47,101 +33,17 @@ const SchemaEditorContainerHeading = styled.h3`
   z-index: -100;
 `;
 
-const getTitle = (schema: JsonSchema | undefined): string => {
-  if (schema === undefined) {
-    return '<not found>';
-  }
-
-  if (typeof schema === 'boolean') {
-    return '<anything>';
-  }
-
-  return schema.title || 'object';
-};
-
-const removeLeadingSlash = (v: string): string => {
-  if (v.startsWith('/')) {
-    return v.slice(1);
-  }
-  return v;
-};
-
 export const SchemaView: React.FC = () => {
   const schema = useParameter<JsonSchema>(PARAM_KEY, {});
-  const lookup = new InternalLookup(schema);
-
-  const getPathFromRoute = (lookup: Lookup): Array<PathElement> => {
-    const basePathSegments = ['base'];
-    const { pathname } = useLocation();
-    const pathSegments = removeLeadingSlash(pathname).split('/');
-    let iterator = 0;
-    while (pathSegments[iterator] !== undefined && basePathSegments[iterator] !== undefined && basePathSegments[iterator] === pathSegments[iterator]) {
-      iterator++;
-    }
-
-    if (iterator === pathSegments.length) {
-      const reference = '#';
-      const title = getTitle(getSchemaFromReference(reference, lookup));
-      return [{
-        title,
-        reference
-      }];
-    }
-
-    return pathSegments.slice(iterator).map(decodeURIComponent).map(userProvidedReference => {
-      const reference = userProvidedReference.startsWith('#') ? userProvidedReference : '#/invalid-reference';
-      const title = getTitle(getSchemaFromReference(reference, lookup));
-      return {
-        title,
-        reference
-      };
-    });
-  };
-
-  const path = getPathFromRoute(lookup);
-  if (path.length === 0) {
-    return <div>Error: Could not work out what to load from the schema.</div>
-  }
-
-  const currentPathElement = path[path.length - 1];
-  const currentSchema = getSchemaFromReference(currentPathElement.reference, lookup);
-
-  if (currentSchema === undefined) {
-    return <div>ERROR: Could not look up the schema that was requested in the URL.</div>;
-  }
-
-  if (typeof currentSchema === 'boolean') {
-    return <div>TODO: Implement anything or nothing schema once clicked on.</div>
-  }
-
-  const explorerArgs: SchemaExplorerProps = {
-    basePathSegments: ['base'],
-    path,
-    lookup,
-    schema: currentSchema,
-    stage: 'both'
-  }
-  const [storybookArgs, updateArgs, resetArgs] = useArgs();
-
-  const handleValidChange = useCallback(
-    debounce(200, (argsString: string) => {
-      try {
-        updateArgs(pack(JSON.parse(decomment(argsString))));
-      } catch (e) {}
-    }),
-    [updateArgs]
-  );
 
   return (
     <SchemaContainer>
-      <SchemaExplorer {...explorerArgs} />
+      <SchemaDoc schema={schema} />
       <SchemaEditorContainer>
-        <SchemaEditor
-          initialContent={unpack(storybookArgs as Record<'string', any>)}
-          schema={schema}
-          handleValidChange={handleValidChange}
-        />
-        <SchemaEditorContainerHeading>Editor and Validator</SchemaEditorContainerHeading>
+        <SchemaEditor schema={schema} />
+        <SchemaEditorContainerHeading>
+          Editor and Validator
+        </SchemaEditorContainerHeading>
       </SchemaEditorContainer>
     </SchemaContainer>
   );

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,8 +1,12 @@
 declare module "global";
 
+interface Args {
+  [key: string]: any;
+}
+
 // TODO add better typings
 declare module "@kickstartds/core/lib/storybook/helpers" {
-  function pack(obj: Record<'string', any>): Record<'string', any>;
-  function unpack(obj: Record<'string', any>): Record<'string', any>;
+  function pack(obj: Args): Args;
+  function unpack(obj: Args): Args;
   function unpackDecorator(story: any, config: any);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2081,10 +2081,10 @@
     sass "^1.43.4"
     vhtml "^2.2.0"
 
-"@kickstartds/json-schema-viewer@^1.0.12":
-  version "1.0.12"
-  resolved "https://registry.npmjs.org/@kickstartds/json-schema-viewer/-/json-schema-viewer-1.0.12.tgz#6e85d5afba898e4d731a0fd9a1de00f976305a39"
-  integrity sha512-/PTfIhBXw5baAHd0N5ufvd+FvY2TBa5aWuI06R30vud2gUOhONDU5+4bYLA7zf4VidxxHigo8+7qEts3pvHoJg==
+"@kickstartds/json-schema-viewer@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/@kickstartds/json-schema-viewer/-/json-schema-viewer-1.1.0.tgz#905ff8132a0da1cfd388edc32f7e8d67cd08408e"
+  integrity sha512-OQ2fYdJGO4lUgEU/spCtiDrMJumGa3hXB/HyoIEmJ8ZKPGoPCrsYfJk6/aS1EzWH3nPZMY0BO869Oo7g/2yrDQ==
   dependencies:
     "@atlaskit/atlassian-navigation" "^0.12.5"
     "@atlaskit/breadcrumbs" "^10.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3404,11 +3404,6 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.7.tgz#545158342f949e8fd3bfd813224971ecddc3fac4"
   integrity sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==
 
-"@types/throttle-debounce@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz#1c3df624bfc4b62f992d3012b84c56d41eab3776"
-  integrity sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==
-
 "@types/uglify-js@*":
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.0.tgz#1cad8df1fb0b143c5aba08de5712ea9d1ff71124"


### PR DESCRIPTION
Änderungen im Editor bewirken ein Update der Args. Und diese hatten dann wieder ein Update des Editors bewirkt, was dazu führte, dass beim Tippen im Editor der Cursor ans Ende des JSON sprang.
Letzteres ist mit diesem PR behoben. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.0-canary.14.54e9997.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/storybook-addon-jsonschema@1.0.0-canary.14.54e9997.0
  # or 
  yarn add @kickstartds/storybook-addon-jsonschema@1.0.0-canary.14.54e9997.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
